### PR TITLE
新建玩家单独的timer 来激活 重启游戏的逻辑，而避免使用根节点的 timer ，优化性能

### DIFF
--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -168,4 +168,9 @@ volume_db = 0.135
 stream = ExtResource("6_x3wgy")
 volume_db = 0.135
 
+[node name="RestartTimer" type="Timer" parent="."]
+wait_time = 3.0
+one_shot = true
+
 [connection signal="timeout" from="Timer" to="." method="_on_fire"]
+[connection signal="timeout" from="RestartTimer" to="." method="_reload_scene"]

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -39,8 +39,9 @@ func game_over():
 		animator.play("lose")
 		get_tree().current_scene.show_game_over()
 		$GameOVerSound.play()
-		await get_tree().create_timer(3).timeout
-		get_tree().reload_current_scene()
+		
+		#等待3秒 重启游戏
+		$RestartTimer.start()
 	
 
 
@@ -54,3 +55,7 @@ func _on_fire() -> void:
 	
 	bullet_node.position = position +bullet_offset
 	get_tree().current_scene.add_child(bullet_node)
+
+
+func _reload_scene() -> void:
+	get_tree().reload_current_scene()


### PR DESCRIPTION
ok